### PR TITLE
Set gbar to zero if not defined

### DIFF
--- a/c++/conductances/bronk/EAGes.hpp
+++ b/c++/conductances/bronk/EAGes.hpp
@@ -25,6 +25,7 @@ public:
         m = m_;
 
         // defaults
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -80; }
     }

--- a/c++/conductances/bronk/EAGmut.hpp
+++ b/c++/conductances/bronk/EAGmut.hpp
@@ -23,7 +23,8 @@ public:
         E = E_;
         m = m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -80; }
     }

--- a/c++/conductances/bronk/EAGwt.hpp
+++ b/c++/conductances/bronk/EAGwt.hpp
@@ -21,7 +21,8 @@ public:
         E = E_;
         m = m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -80; }
 

--- a/c++/conductances/caplan/MICurrent.hpp
+++ b/c++/conductances/caplan/MICurrent.hpp
@@ -23,6 +23,7 @@ public:
         m = m_;
 
         // defaults
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = 30; }
     }

--- a/c++/conductances/hardie-laughlin/Shaker.hpp
+++ b/c++/conductances/hardie-laughlin/Shaker.hpp
@@ -23,7 +23,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = -80; }

--- a/c++/conductances/lin/NaP.hpp
+++ b/c++/conductances/lin/NaP.hpp
@@ -21,6 +21,7 @@ public:
         m = m_;
 
         // defaults
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = 50; }
     }

--- a/c++/conductances/lin/NaT.hpp
+++ b/c++/conductances/lin/NaT.hpp
@@ -21,7 +21,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 50; }

--- a/c++/conductances/liu-approx/ACurrent.hpp
+++ b/c++/conductances/liu-approx/ACurrent.hpp
@@ -26,7 +26,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = -80; }

--- a/c++/conductances/liu-approx/CaS.hpp
+++ b/c++/conductances/liu-approx/CaS.hpp
@@ -22,6 +22,7 @@ public:
         h = h_;
 
         // defaults
+    if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 30; }

--- a/c++/conductances/liu-approx/CaT.hpp
+++ b/c++/conductances/liu-approx/CaT.hpp
@@ -22,7 +22,8 @@ public:
         h = h_;
 
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 30; }

--- a/c++/conductances/liu-approx/HCurrent.hpp
+++ b/c++/conductances/liu-approx/HCurrent.hpp
@@ -21,7 +21,8 @@ public:
         E = E_;
         m = m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -20; }
 

--- a/c++/conductances/liu-approx/KCa.hpp
+++ b/c++/conductances/liu-approx/KCa.hpp
@@ -23,7 +23,8 @@ public:
         E = E_;
         m = m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = 30; }
 

--- a/c++/conductances/liu-approx/Kd.hpp
+++ b/c++/conductances/liu-approx/Kd.hpp
@@ -20,7 +20,8 @@ public:
         E = E_;
         m = m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -80; }
 

--- a/c++/conductances/liu-approx/NaV.hpp
+++ b/c++/conductances/liu-approx/NaV.hpp
@@ -21,7 +21,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 30; }

--- a/c++/conductances/liu-euler/ACurrent.hpp
+++ b/c++/conductances/liu-euler/ACurrent.hpp
@@ -24,7 +24,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = -20; }

--- a/c++/conductances/liu-euler/CaS.hpp
+++ b/c++/conductances/liu-euler/CaS.hpp
@@ -21,7 +21,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 30; }

--- a/c++/conductances/liu-euler/CaT.hpp
+++ b/c++/conductances/liu-euler/CaT.hpp
@@ -21,7 +21,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 30; }

--- a/c++/conductances/liu-euler/HCurrent.hpp
+++ b/c++/conductances/liu-euler/HCurrent.hpp
@@ -21,7 +21,8 @@ public:
         E = E_;
         m = m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -80; }
 

--- a/c++/conductances/liu-euler/KCa.hpp
+++ b/c++/conductances/liu-euler/KCa.hpp
@@ -20,7 +20,8 @@ public:
         E = E_;
         m = m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -80; }
     }

--- a/c++/conductances/liu-euler/Kd.hpp
+++ b/c++/conductances/liu-euler/Kd.hpp
@@ -20,7 +20,8 @@ public:
         E = E_;
         m = m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -80; }
     }

--- a/c++/conductances/liu-euler/NaV.hpp
+++ b/c++/conductances/liu-euler/NaV.hpp
@@ -21,7 +21,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 30; }

--- a/c++/conductances/liu-temperature/ACurrent.hpp
+++ b/c++/conductances/liu-temperature/ACurrent.hpp
@@ -27,7 +27,8 @@ public:
         Q_tau_m = Q_tau_m_;
         Q_tau_h = Q_tau_h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (Q_g)) { Q_g = 1; }

--- a/c++/conductances/liu-temperature/CaS.hpp
+++ b/c++/conductances/liu-temperature/CaS.hpp
@@ -26,7 +26,8 @@ public:
         Q_tau_m = Q_tau_m_;
         Q_tau_h = Q_tau_h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (Q_g)) { Q_g = 1; }

--- a/c++/conductances/liu-temperature/CaT.hpp
+++ b/c++/conductances/liu-temperature/CaT.hpp
@@ -26,7 +26,8 @@ public:
         Q_tau_m = Q_tau_m_;
         Q_tau_h = Q_tau_h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (Q_g)) { Q_g = 1; }

--- a/c++/conductances/liu-temperature/HCurrent.hpp
+++ b/c++/conductances/liu-temperature/HCurrent.hpp
@@ -26,7 +26,8 @@ public:
         Q_tau_m = Q_tau_m_;
         Q_tau_h = Q_tau_h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (Q_g)) { Q_g = 1; }

--- a/c++/conductances/liu-temperature/KCa.hpp
+++ b/c++/conductances/liu-temperature/KCa.hpp
@@ -25,7 +25,8 @@ public:
         Q_tau_m = Q_tau_m_;
         Q_tau_h = Q_tau_h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (Q_g)) { Q_g = 1; }

--- a/c++/conductances/liu-temperature/Kd.hpp
+++ b/c++/conductances/liu-temperature/Kd.hpp
@@ -25,7 +25,8 @@ public:
         Q_tau_m = Q_tau_m_;
         Q_tau_h = Q_tau_h_;
 
-                // defaults
+                // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (Q_g)) { Q_g = 1; }

--- a/c++/conductances/liu-temperature/NaV.hpp
+++ b/c++/conductances/liu-temperature/NaV.hpp
@@ -25,7 +25,8 @@ public:
         Q_tau_m = Q_tau_m_;
         Q_tau_h = Q_tau_h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (Q_g)) { Q_g = 1; }

--- a/c++/conductances/liu/ACurrent.hpp
+++ b/c++/conductances/liu/ACurrent.hpp
@@ -24,7 +24,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = -20; }

--- a/c++/conductances/liu/CaS.hpp
+++ b/c++/conductances/liu/CaS.hpp
@@ -21,7 +21,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 30; }

--- a/c++/conductances/liu/CaT.hpp
+++ b/c++/conductances/liu/CaT.hpp
@@ -21,7 +21,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 30; }

--- a/c++/conductances/liu/HCurrent.hpp
+++ b/c++/conductances/liu/HCurrent.hpp
@@ -21,7 +21,8 @@ public:
         E = E_;
         m = m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -80; }
 

--- a/c++/conductances/liu/KCa.hpp
+++ b/c++/conductances/liu/KCa.hpp
@@ -20,7 +20,8 @@ public:
         E = E_;
         m = m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -80; }
     }

--- a/c++/conductances/liu/Kd.hpp
+++ b/c++/conductances/liu/Kd.hpp
@@ -20,7 +20,8 @@ public:
         E = E_;
         m = m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -80; }
     }

--- a/c++/conductances/liu/NaV.hpp
+++ b/c++/conductances/liu/NaV.hpp
@@ -21,7 +21,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 30; }

--- a/c++/conductances/odowd-aldrich/DmNaV.hpp
+++ b/c++/conductances/odowd-aldrich/DmNaV.hpp
@@ -24,7 +24,8 @@ public:
         m = m_;
         h = h_;
 
-         // defaults
+         // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 50; }

--- a/c++/conductances/prinz-approx/ACurrent.hpp
+++ b/c++/conductances/prinz-approx/ACurrent.hpp
@@ -25,7 +25,8 @@ public:
         h = h_;
 
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = -80; }

--- a/c++/conductances/prinz-approx/CaS.hpp
+++ b/c++/conductances/prinz-approx/CaS.hpp
@@ -21,7 +21,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 30; }

--- a/c++/conductances/prinz-approx/CaT.hpp
+++ b/c++/conductances/prinz-approx/CaT.hpp
@@ -21,7 +21,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 30; }

--- a/c++/conductances/prinz-approx/HCurrent.hpp
+++ b/c++/conductances/prinz-approx/HCurrent.hpp
@@ -22,7 +22,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = -20; }

--- a/c++/conductances/prinz-approx/KCa.hpp
+++ b/c++/conductances/prinz-approx/KCa.hpp
@@ -24,7 +24,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 30; }

--- a/c++/conductances/prinz-approx/Kd.hpp
+++ b/c++/conductances/prinz-approx/Kd.hpp
@@ -21,7 +21,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = -80; }

--- a/c++/conductances/prinz-approx/NaV.hpp
+++ b/c++/conductances/prinz-approx/NaV.hpp
@@ -21,7 +21,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 30; }

--- a/c++/conductances/prinz-temperature/ACurrent.hpp
+++ b/c++/conductances/prinz-temperature/ACurrent.hpp
@@ -29,7 +29,8 @@ public:
         Q_tau_m = Q_tau_m_;
         Q_tau_h = Q_tau_h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (Q_g)) { Q_g = 1; }

--- a/c++/conductances/prinz-temperature/CaS.hpp
+++ b/c++/conductances/prinz-temperature/CaS.hpp
@@ -25,7 +25,8 @@ public:
         Q_tau_m = Q_tau_m_;
         Q_tau_h = Q_tau_h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (Q_g)) { Q_g = 1; }

--- a/c++/conductances/prinz-temperature/CaT.hpp
+++ b/c++/conductances/prinz-temperature/CaT.hpp
@@ -25,7 +25,8 @@ public:
         Q_tau_m = Q_tau_m_;
         Q_tau_h = Q_tau_h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (Q_g)) { Q_g = 1; }

--- a/c++/conductances/prinz-temperature/HCurrent.hpp
+++ b/c++/conductances/prinz-temperature/HCurrent.hpp
@@ -25,7 +25,8 @@ public:
         Q_g = Q_g_;
         Q_tau_m = Q_tau_m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (Q_g)) { Q_g = 1; }

--- a/c++/conductances/prinz-temperature/KCa.hpp
+++ b/c++/conductances/prinz-temperature/KCa.hpp
@@ -23,7 +23,8 @@ public:
         Q_g = Q_g_;
         Q_tau_m = Q_tau_m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (Q_g)) { Q_g = 1; }
         if (isnan (Q_tau_m)) { Q_tau_m = 1; }

--- a/c++/conductances/prinz-temperature/Kd.hpp
+++ b/c++/conductances/prinz-temperature/Kd.hpp
@@ -23,7 +23,8 @@ public:
         Q_g = Q_g_;
         Q_tau_m = Q_tau_m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (Q_g)) { Q_g = 1; }
         if (isnan (Q_tau_m)) { Q_tau_m = 1; }

--- a/c++/conductances/prinz-temperature/NaV.hpp
+++ b/c++/conductances/prinz-temperature/NaV.hpp
@@ -26,7 +26,8 @@ public:
         Q_tau_m = Q_tau_m_;
         Q_tau_h = Q_tau_h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
             if (isnan (m)) { m = 0; }
             if (isnan (h)) { h = 1; }
             if (isnan (Q_g)) { Q_g = 1; }

--- a/c++/conductances/prinz/ACurrent.hpp
+++ b/c++/conductances/prinz/ACurrent.hpp
@@ -25,7 +25,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = -20; }

--- a/c++/conductances/prinz/CaS.hpp
+++ b/c++/conductances/prinz/CaS.hpp
@@ -22,7 +22,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 30; }

--- a/c++/conductances/prinz/CaT.hpp
+++ b/c++/conductances/prinz/CaT.hpp
@@ -22,7 +22,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 20; }

--- a/c++/conductances/prinz/HCurrent.hpp
+++ b/c++/conductances/prinz/HCurrent.hpp
@@ -22,7 +22,8 @@ public:
         E = E_;
         m = m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -20; }
     }

--- a/c++/conductances/prinz/KCa.hpp
+++ b/c++/conductances/prinz/KCa.hpp
@@ -21,7 +21,8 @@ public:
         E = E_;
         m = m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = -20; }

--- a/c++/conductances/prinz/Kd.hpp
+++ b/c++/conductances/prinz/Kd.hpp
@@ -21,7 +21,8 @@ public:
         E = E_;
         m = m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -20; }
 

--- a/c++/conductances/prinz/NaV.hpp
+++ b/c++/conductances/prinz/NaV.hpp
@@ -22,7 +22,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = -20; }

--- a/c++/conductances/sharp/MICurrent.hpp
+++ b/c++/conductances/sharp/MICurrent.hpp
@@ -22,7 +22,8 @@ public:
         E = E_;
         m = m_;
 
-         // defaults
+         // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -20; }
     }

--- a/c++/conductances/soto-trevino/ACurrentAB.hpp
+++ b/c++/conductances/soto-trevino/ACurrentAB.hpp
@@ -21,7 +21,8 @@ public:
         m = m_;
         h = h_;
 
-         // defaults
+         // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = -20; }

--- a/c++/conductances/soto-trevino/ACurrentPD.hpp
+++ b/c++/conductances/soto-trevino/ACurrentPD.hpp
@@ -21,7 +21,8 @@ public:
         m = m_;
         h = h_;
 
-         // defaults
+         // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = -20; }

--- a/c++/conductances/soto-trevino/CaS.hpp
+++ b/c++/conductances/soto-trevino/CaS.hpp
@@ -21,7 +21,8 @@ public:
         m = m_;
         h = h_;
 
-         // defaults
+         // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 50; }

--- a/c++/conductances/soto-trevino/CaTAB.hpp
+++ b/c++/conductances/soto-trevino/CaTAB.hpp
@@ -21,7 +21,8 @@ public:
         m = m_;
         h = h_;
 
-         // defaults
+         // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 50; }

--- a/c++/conductances/soto-trevino/CaTPD.hpp
+++ b/c++/conductances/soto-trevino/CaTPD.hpp
@@ -17,7 +17,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 50; }

--- a/c++/conductances/soto-trevino/HCurrent.hpp
+++ b/c++/conductances/soto-trevino/HCurrent.hpp
@@ -20,7 +20,8 @@ public:
         E = E_;
         m = m_;
 
-         // defaults
+         // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -20; }
     }

--- a/c++/conductances/soto-trevino/KCaAB.hpp
+++ b/c++/conductances/soto-trevino/KCaAB.hpp
@@ -20,7 +20,8 @@ public:
         E = E_;
         m = m_;
 
-         // defaults
+         // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -80; }
     }

--- a/c++/conductances/soto-trevino/KCaPD.hpp
+++ b/c++/conductances/soto-trevino/KCaPD.hpp
@@ -20,7 +20,8 @@ public:
         E = E_;
         m = m_;
 
-         // defaults
+         // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -80; }
     }

--- a/c++/conductances/soto-trevino/Kd.hpp
+++ b/c++/conductances/soto-trevino/Kd.hpp
@@ -20,7 +20,8 @@ public:
         E = E_;
         m = m_;
 
-         // defaults
+         // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -80; }
 

--- a/c++/conductances/soto-trevino/NaP.hpp
+++ b/c++/conductances/soto-trevino/NaP.hpp
@@ -21,7 +21,8 @@ public:
         m = m_;
         h = h_;
 
-         // defaults
+         // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 50; }

--- a/c++/conductances/soto-trevino/NaV.hpp
+++ b/c++/conductances/soto-trevino/NaV.hpp
@@ -21,7 +21,8 @@ public:
         m = m_;
         h = h_;
 
-         // defaults
+         // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = -80; }

--- a/c++/conductances/soto-trevino/Proc.hpp
+++ b/c++/conductances/soto-trevino/Proc.hpp
@@ -21,7 +21,8 @@ public:
         E = E_;
         m = m_;
 
-         // defaults
+         // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = 0; }
     }

--- a/c++/conductances/swensen/MICurrent.hpp
+++ b/c++/conductances/swensen/MICurrent.hpp
@@ -22,7 +22,8 @@ public:
         E = E_;
         m = m_;
 
-         // defaults
+         // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = 0; }
 

--- a/c++/conductances/turrigiano/ACurrent.hpp
+++ b/c++/conductances/turrigiano/ACurrent.hpp
@@ -24,7 +24,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = -20; }

--- a/c++/conductances/turrigiano/ASlow.hpp
+++ b/c++/conductances/turrigiano/ASlow.hpp
@@ -24,7 +24,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = -20; }

--- a/c++/conductances/turrigiano/Ca1.hpp
+++ b/c++/conductances/turrigiano/Ca1.hpp
@@ -23,7 +23,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 120; }

--- a/c++/conductances/turrigiano/Ca2.hpp
+++ b/c++/conductances/turrigiano/Ca2.hpp
@@ -22,7 +22,8 @@ public:
         E = E_;
         m = m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = 120; }
 

--- a/c++/conductances/turrigiano/HCurrent.hpp
+++ b/c++/conductances/turrigiano/HCurrent.hpp
@@ -21,7 +21,8 @@ public:
         E = E_;
         m = m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -80; }
 

--- a/c++/conductances/turrigiano/KCa.hpp
+++ b/c++/conductances/turrigiano/KCa.hpp
@@ -20,7 +20,8 @@ public:
         E = E_;
         m = m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -80; }
     }

--- a/c++/conductances/turrigiano/Kd.hpp
+++ b/c++/conductances/turrigiano/Kd.hpp
@@ -20,7 +20,8 @@ public:
         E = E_;
         m = m_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -80; }
     }

--- a/c++/conductances/turrigiano/NaP.hpp
+++ b/c++/conductances/turrigiano/NaP.hpp
@@ -22,7 +22,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 50; }

--- a/c++/conductances/turrigiano/NaV.hpp
+++ b/c++/conductances/turrigiano/NaV.hpp
@@ -22,7 +22,8 @@ public:
         m = m_;
         h = h_;
 
-        // defaults
+        // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 50; }

--- a/c++/conductances/wicher/DmNaV.hpp
+++ b/c++/conductances/wicher/DmNaV.hpp
@@ -21,7 +21,8 @@ public:
         m = m_;
         h = h_;
 
-         // defaults
+         // defaults 
+ if (isnan(gbar)) { gbar = 0; }
         if (isnan (m)) { m = 0; }
         if (isnan (h)) { h = 1; }
         if (isnan (E)) { E = 50; }


### PR DESCRIPTION
integral control test fails on Manjaro, passes on macOS 10.12

```
/home/marder/code/xolotl/c++/controllers/IntegralController.hpp: In member function ‘virtual double
IntegralController::getState(int)’:
/home/marder/code/xolotl/c++/controllers/IntegralController.hpp:56:23: error: ‘numeric_limits’ is not a member of ‘std’
     else {return std::numeric_limits<double>::quiet_NaN();}
                       ^~~~~~~~~~~~~~
```