### PR TITLE
Fix traub conductances

### DIFF
--- a/c++/conductances/traub/ACurrent.hpp
+++ b/c++/conductances/traub/ACurrent.hpp
@@ -37,8 +37,6 @@ public:
         if (isnan (E)) { E = -80; }
     }
 
-    void integrate(double, double);
-
     double m_inf(double, double);
     double h_inf(double, double);
     double tau_m(double, double);

--- a/c++/conductances/traub/KCa.hpp
+++ b/c++/conductances/traub/KCa.hpp
@@ -7,12 +7,12 @@
 // as described in Traub et al. 1991
 // https://www.researchgate.net/publication/21491281_A_Model_of_CA3_Hippocampal_Pyramidal_Neuron_Incorporating_Voltage-Clamp_Data_on_Intrinsic_Conductances
 
-#ifndef KC
-#define KC
+#ifndef KCA
+#define KCA
 #include "conductance.hpp"
 
 //inherit conductance class spec
-class Kc: public conductance {
+class KCa: public conductance {
 
 protected:
 
@@ -23,7 +23,7 @@ public:
 
 
     // specify parameters + initial conditions
-    Kc(double g_, double E_, double m_)
+    KCa(double g_, double E_, double m_)
     {
         gbar = g_;
         E = E_;
@@ -44,17 +44,17 @@ public:
 };
 
 
-string Kc::getClass(){
-    return "Kc";
+string KCa::getClass(){
+    return "KCa";
 }
 
-void Kc::integrate(double V, double Ca)
+void KCa::integrate(double V, double Ca)
 {
     m = m_inf(V,Ca) + (m - m_inf(V,Ca))*exp(-dt/tau_m(V,Ca));
     g = gbar * m * min(1.0, Ca / 250.0);
 }
 
-double Kc::m_inf(double V, double Ca) {
+double KCa::m_inf(double V, double Ca) {
     if (V <= -50.0) {
         alpha = exp(((V-10.0)/11.0)-((V-6.5)/27.0))/18.975;
         beta = 2*exp(-(V-6.5)/27.0) - alpha;
@@ -63,7 +63,7 @@ double Kc::m_inf(double V, double Ca) {
     return 1.0;
 }
 
-double Kc::tau_m(double V, double Ca) {
+double KCa::tau_m(double V, double Ca) {
     if (V <= -50.0) {
         alpha = exp(((V-10.0)/11.0)-((V-6.5)/27.0))/18.975;
         beta = 2*exp(-(V-6.5)/27.0) - alpha;

--- a/c++/conductances/traub/Kahp.hpp
+++ b/c++/conductances/traub/Kahp.hpp
@@ -29,9 +29,7 @@ public:
         if (isnan (m)) { m = 0; }
         if (isnan (E)) { E = -80; }
     }
-
-    void integrate(double, double);
-
+    
     double m_inf(double V, double Ca);
     double tau_m(double, double);
     string getClass(void);

--- a/c++/conductances/traub/Kd.hpp
+++ b/c++/conductances/traub/Kd.hpp
@@ -33,8 +33,6 @@ public:
         if (isnan (E)) { E = -80; }
     }
 
-    void integrate(double, double);
-
     double m_inf(double, double);
     double tau_m(double, double);
     string getClass(void);

--- a/c++/conductances/traub/NaV.hpp
+++ b/c++/conductances/traub/NaV.hpp
@@ -37,8 +37,6 @@ public:
         if (isnan (E)) { E = 50; }
     }
 
-    void integrate(double, double);
-
     double m_inf(double, double);
     double h_inf(double, double);
     double tau_m(double, double);


### PR DESCRIPTION
`integrate` methods were not removed from traub conductances. This causes a fatal error. Removing the method causes the class to default to the generic conductance class' method.

Rename `Kc` current to `KCa` current.